### PR TITLE
Fix wrong checkCipherHashIsAvailable compare param

### DIFF
--- a/phalcon/Encryption/Crypt.zep
+++ b/phalcon/Encryption/Crypt.zep
@@ -590,7 +590,7 @@ class Crypt implements CryptInterface
     {
         var available, lower, method;
 
-        if "hash" === cipher {
+        if "hash" === type {
             let method = "getAvailableHashAlgorithms";
         } else {
             let method = "getAvailableCiphers";


### PR DESCRIPTION
You can't specify $crypt->setHashAlgorithm('sha256'); because of a wrong use of compare "hash" === cipher in function Crypt->checkCipherHashIsAvailable

Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Thanks

